### PR TITLE
Pass CPU+OS_SOURCE to make during FPCNative builds

### DIFF
--- a/installerfpc.pas
+++ b/installerfpc.pas
@@ -891,6 +891,8 @@ begin
   {$ELSE}
   Processor.Parameters.Add('UPXPROG=echo'); //Don't use UPX
   Processor.Parameters.Add('COPYTREE=echo'); //fix for examples in Win svn, see build FAQ
+  Processor.Parameters.Add('CPU_SOURCE='+GetTargetCPU);
+  Processor.Parameters.Add('OS_SOURCE='+GetTargetOS);
   {$ENDIF}
 
   Processor.Parameters.Add('REVSTR='+ActualRevision);


### PR DESCRIPTION
This change allows using a crossompiler binary to bootstrap a native compiler. We only need to pass SOURCE to get the correct include paths, as TARGET is set by the compiler itself (same as old behaviour). Nothing changes if the source compiler is already native, it would have the values explicitly set here by default anyway.

Fixes the issue mentioned in the first comment on #36. 